### PR TITLE
Remove autofocus from email field

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -360,7 +360,7 @@
      style="background: rgba(255,255,255,0.5);">
       <label for="inputEmail" class="sr-only">
 	Email address</label>
-      <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required autofocus>
+      <input type="email" id="inputEmail" class="form-control" placeholder="Email address" required>
       <button class="btn btn-md btn-primary btn-block" type="button"
 	data-toggle="modal" data-target="#subscribe-dialog">
 	Subscribe</button>


### PR DESCRIPTION
Remove autofocus from #email field to fix the page's wrong initial postion.
